### PR TITLE
(PSNotifySend-6) Added powershell-logo.png to the build script as it was missing.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -77,6 +77,7 @@ else {
         Copy-Item -Path "$PSScriptRoot\src\PSNotifySend.ps*1" -Destination "$PSScriptRoot\out\PSNotifySend\" -Force
         Copy-Item -Path "$PSScriptRoot\README.md" -Destination "$PSScriptRoot\out\PSNotifySend\" -Force
         Copy-Item -Path "$PSScriptRoot\LICENSE" -Destination "$PSScriptRoot\out\PSNotifySend\" -Force
+        Copy-Item -Path "$PSScriptRoot\src\powershell-logo.png" -Destination "$PSScriptRoot\out\PSNotifySend\" -Force
         Copy-Item -Path "$PSScriptRoot\src\Public" -Destination "$PSScriptRoot\out\PSNotifySend\" -Force -Recurse
         Copy-Item -Path "$PSScriptRoot\src\Private" -Destination "$PSScriptRoot\out\PSNotifySend\" -Force -Recurse
     }


### PR DESCRIPTION
The powershell-logo.png was missing from the build script. As such it wasn't being included in the module when it was pushed to the Gallery. 

Added 
`Copy-Item -Path "$PSScriptRoot\src\powershell-logo.png" -Destination"$PSScriptRoot\out\PSNotifySend\" -Force` to correct the problem

Fixes #6
